### PR TITLE
fix: prevents event taxonomy from breaking page

### DIFF
--- a/web/app/plugins/froware/public/class-filterbar-filter-taxonomy.php
+++ b/web/app/plugins/froware/public/class-filterbar-filter-taxonomy.php
@@ -45,7 +45,7 @@ abstract class Filterbar_Filter_Taxonomy extends Tribe__Events__Filterbar__Filte
 		// Re-order!
 		foreach ( $terms as $id => $term ) {
 			// Skip root elements
-			if ( 0 === $term->parent ) {
+			if ( 0 === $term->parent || ! isset( $terms[ $term->parent ] ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Closes #728